### PR TITLE
Added the option to specify label fonts

### DIFF
--- a/kiss_sdl.h
+++ b/kiss_sdl.h
@@ -118,6 +118,7 @@ typedef struct kiss_label {
 	int visible;
 	char text[KISS_MAX_LABEL];
 	SDL_Color textcolor;
+	kiss_font font;
 	kiss_window *wdw;
 } kiss_label;
 

--- a/kiss_widgets.c
+++ b/kiss_widgets.c
@@ -68,6 +68,7 @@ int kiss_label_new(kiss_label *label, kiss_window *wdw, char *text,
 {
 	if (!label || !text) return -1;
 	label->textcolor = kiss_black;
+	label->font = kiss_textfont;
 	kiss_makerect(&label->rect, x, y, 0, 0);
 	kiss_string_copy(label->text, KISS_MAX_LABEL, text, NULL);
 	label->visible = 0;
@@ -82,7 +83,7 @@ int kiss_label_draw(kiss_label *label, SDL_Renderer *renderer)
 
 	if (label && label->wdw) label->visible = label->wdw->visible;
 	if (!label || !label->visible || !renderer) return 0;
-	y = label->rect.y + kiss_textfont.spacing / 2;
+	y = label->rect.y + label->font.spacing / 2;
 	len = strlen(label->text);
 	if (len > KISS_MAX_LABEL - 2)
 		label->text[len - 1] = '\n';
@@ -91,8 +92,8 @@ int kiss_label_draw(kiss_label *label, SDL_Renderer *renderer)
 	for (p = label->text; *p; p = strchr(p, '\n') + 1) {
 		kiss_string_copy(buf, strcspn(p, "\n") + 1, p, NULL);
 		kiss_rendertext(renderer, buf, label->rect.x, y,
-			kiss_textfont, label->textcolor);
-		y += kiss_textfont.lineheight;
+			label->font, label->textcolor);
+		y += label->font.lineheight;
 	}
 	label->text[len] = 0;
 	return 1;


### PR DESCRIPTION
This makes labels more modular and useful by allowing them to use different fonts. Before, a new kiss_label_draw function would have to be written to accomplish this. Labels still use the kiss_textfont by default, which ensures that all examples and old projects will still work after this change. I have tested my changes on OSX 10.11.6 Beta (15G12a), using CMake 3 and Clang/LLVM (Apple LLVM version 7.3.0, clang-703.0.29). This change has _not_ been tested in a pure C project (including the default KISS_SDL examples)!

I'm planning on updating all/most of the default widgets to allow for this kind of customization and convenience in my own projects, and if this change is appreciated, will make another pull request soon to add it to the master branch. I understand if you'd prefer to leave "specializations" up to users, and please don't worry about rejecting the merge simply for that reason. This is something that I feel improves KISS_SDL, making it easier to use for me, however I understand that perhaps not everyone would feel that way.

Thanks for taking a look at this! Please let me know if I made some error in the code, or overlooked a specific case.

Michael
