### PR TITLE
Complete support for high DPI displays

### DIFF
--- a/kiss_draw.c
+++ b/kiss_draw.c
@@ -29,6 +29,7 @@ kiss_image kiss_normal, kiss_prelight, kiss_active, kiss_bar,
 	kiss_up, kiss_down, kiss_left, kiss_right, kiss_vslider,
 	kiss_hslider, kiss_selected, kiss_unselected, kiss_combo;
 int kiss_screen_width, kiss_screen_height;
+int kiss_screen_scale_factor;
 int kiss_textfont_size = 15;
 int kiss_buttonfont_size = 12;
 int kiss_click_interval = 140;
@@ -191,8 +192,12 @@ SDL_Renderer* kiss_init(char* title, kiss_array *a, int w, int h)
 	SDL_StartTextInput();
 	kiss_array_new(a);
 	window = SDL_CreateWindow(title, srect.w / 2 - w / 2,
-		srect.h / 2 - h / 2, w, h, SDL_WINDOW_SHOWN);
-	if (window) kiss_array_append(a, WINDOW_TYPE, window);
+		srect.h / 2 - h / 2, w, h, SDL_WINDOW_ALLOW_HIGHDPI);
+	if (window) {
+		kiss_array_append(a, WINDOW_TYPE, window);
+		SDL_GL_GetDrawableSize (window, &kiss_screen_width, &kiss_screen_height);
+		kiss_screen_scale_factor = kiss_screen_width / w;
+	}
 	renderer = SDL_CreateRenderer(window, -1,
 		SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
 	if (renderer) kiss_array_append(a, RENDERER_TYPE, renderer);

--- a/kiss_draw.c
+++ b/kiss_draw.c
@@ -29,7 +29,7 @@ kiss_image kiss_normal, kiss_prelight, kiss_active, kiss_bar,
 	kiss_up, kiss_down, kiss_left, kiss_right, kiss_vslider,
 	kiss_hslider, kiss_selected, kiss_unselected, kiss_combo;
 int kiss_screen_width, kiss_screen_height;
-int kiss_screen_scale_factor;
+int kiss_screen_scalefactor;
 int kiss_textfont_size = 15;
 int kiss_buttonfont_size = 12;
 int kiss_click_interval = 140;
@@ -196,7 +196,7 @@ SDL_Renderer* kiss_init(char* title, kiss_array *a, int w, int h)
 	if (window) {
 		kiss_array_append(a, WINDOW_TYPE, window);
 		SDL_GL_GetDrawableSize (window, &kiss_screen_width, &kiss_screen_height);
-		kiss_screen_scale_factor = kiss_screen_width / w;
+		kiss_screen_scalefactor = kiss_screen_width / w;
 	}
 	renderer = SDL_CreateRenderer(window, -1,
 		SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);

--- a/kiss_general.c
+++ b/kiss_general.c
@@ -36,8 +36,8 @@ int kiss_makerect(SDL_Rect *rect, int x, int y, int w, int h)
 
 int kiss_pointinrect(int x, int y, SDL_Rect *rect)
 {
-	return (x * kiss_screen_scale_factor) >= rect->x && (x * kiss_screen_scale_factor) < rect->x + rect->w &&
-		(y * kiss_screen_scale_factor) >= rect->y && (y * kiss_screen_scale_factor) < rect->y + rect->h;
+	return (x * kiss_screen_scalefactor) >= rect->x && (x * kiss_screen_scalefactor) < rect->x + rect->w &&
+		(y * kiss_screen_scalefactor) >= rect->y && (y * kiss_screen_scalefactor) < rect->y + rect->h;
 }
 
 int kiss_utf8next(char *str, int index)

--- a/kiss_general.c
+++ b/kiss_general.c
@@ -36,8 +36,8 @@ int kiss_makerect(SDL_Rect *rect, int x, int y, int w, int h)
 
 int kiss_pointinrect(int x, int y, SDL_Rect *rect)
 {
-	return x >= rect->x && x < rect->x + rect->w &&
-		y >= rect->y && y < rect->y + rect->h;
+	return (x * kiss_screen_scale_factor) >= rect->x && (x * kiss_screen_scale_factor) < rect->x + rect->w &&
+		(y * kiss_screen_scale_factor) >= rect->y && (y * kiss_screen_scale_factor) < rect->y + rect->h;
 }
 
 int kiss_utf8next(char *str, int index)

--- a/kiss_sdl.h
+++ b/kiss_sdl.h
@@ -268,6 +268,7 @@ extern int kiss_click_interval, kiss_progress_interval;
 extern int kiss_slider_padding;
 extern int kiss_border, kiss_edge;
 extern int kiss_screen_width, kiss_screen_height;
+extern int kiss_screen_scale_factor;
 
 #ifdef __cplusplus
 extern "C" {

--- a/kiss_sdl.h
+++ b/kiss_sdl.h
@@ -268,7 +268,7 @@ extern int kiss_click_interval, kiss_progress_interval;
 extern int kiss_slider_padding;
 extern int kiss_border, kiss_edge;
 extern int kiss_screen_width, kiss_screen_height;
-extern int kiss_screen_scale_factor;
+extern int kiss_screen_scalefactor;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This pull request enables kiss_sdl to fully utilize high DPI displays via an SDL hint, and changes kiss_pointinrect to use correct event positions for any DPI. The problem was that kiss_pointinrect was working exclusively in pixels (because SDL_Event works in pixels), while a high DPI display uses points. Also, kiss_screen_width and kiss_screen_height now update to high DPI values. This fixes the issue I found with https://github.com/actsl/kiss_sdl/pull/9 .

Please note: on the [(SDL Wiki)](https://wiki.libsdl.org/SDL_CreateWindow) it says _SDL_WINDOW_SHOWN is ignored by SDL_CreateWindow(). The SDL_Window is implicitly shown if SDL_WINDOW_HIDDEN is not set._ , so I removed it.

Finally, for SDL to receive a high DPI canvas in a **packaged** macOS application, _NSHighResolutionCapable_ must be set to _YES_ in the application's Info.plist.

I have successfully tested this on a retina MacBook Pro (my project designed on a non-high-DPI computer scaled perfectly), and a non Retina iMac (everything worked as it did before; no errors).

Thank you!
Michael
